### PR TITLE
Add custom API server URL option

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -88,6 +88,8 @@ namespace osu.Game.Configuration
                 }
             };
 
+            SetDefault(OsuSetting.CustomApiUrl, string.Empty);
+
             SetDefault(OsuSetting.ExternalLinkWarning, true);
             SetDefault(OsuSetting.PreferNoVideo, false);
 
@@ -468,6 +470,11 @@ namespace osu.Game.Configuration
         EditorShowStoryboard,
         EditorSubmissionNotifyOnDiscussionReplies,
         EditorSubmissionLoadInBrowserAfterSubmission,
+
+        /// <summary>
+        /// Custom API endpoint URL.
+        /// </summary>
+        CustomApiUrl,
 
         /// <summary>
         /// Cached state of whether local user is a supporter.

--- a/osu.Game/Localisation/OnlineSettingsStrings.cs
+++ b/osu.Game/Localisation/OnlineSettingsStrings.cs
@@ -94,6 +94,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString HideCountryFlags => new TranslatableString(getKey(@"hide_country_flags"), @"Hide country flags");
 
+        /// <summary>
+        /// "Custom API server URL"
+        /// </summary>
+        public static LocalisableString CustomApiUrl => new TranslatableString(getKey(@"custom_api_url"), @"Custom API server URL");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -104,8 +104,25 @@ namespace osu.Game
 
         public virtual bool UseDevelopmentServer => DebugUtils.IsDebugBuild;
 
-        public virtual EndpointConfiguration CreateEndpoints() =>
-            UseDevelopmentServer ? new DevelopmentEndpointConfiguration() : new ProductionEndpointConfiguration();
+        public virtual EndpointConfiguration CreateEndpoints()
+        {
+            EndpointConfiguration config = UseDevelopmentServer ? new DevelopmentEndpointConfiguration() : new ProductionEndpointConfiguration();
+
+            string customUrl = LocalConfig?.Get<string>(OsuSetting.CustomApiUrl);
+
+            if (!string.IsNullOrEmpty(customUrl))
+            {
+                customUrl = customUrl.TrimEnd('/');
+                config.APIUrl = customUrl;
+                config.WebsiteUrl = customUrl;
+                config.SpectatorUrl = $"{customUrl}/signalr/spectator";
+                config.MultiplayerUrl = $"{customUrl}/signalr/multiplayer";
+                config.MetadataUrl = $"{customUrl}/signalr/metadata";
+                config.BeatmapSubmissionServiceUrl = $"{customUrl}/beatmap-submission";
+            }
+
+            return config;
+        }
 
         protected override OnlineStore CreateOnlineStore() => new TrustedDomainOnlineStore();
 

--- a/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
@@ -40,6 +41,11 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                     LabelText = OnlineSettingsStrings.ShowExplicitContent,
                     Keywords = new[] { "nsfw", "18+", "offensive" },
                     Current = config.GetBindable<bool>(OsuSetting.ShowOnlineExplicitContent),
+                },
+                new SettingsTextBox
+                {
+                    LabelText = OnlineSettingsStrings.CustomApiUrl,
+                    Current = config.GetBindable<string>(OsuSetting.CustomApiUrl)
                 }
             };
         }


### PR DESCRIPTION
## Summary
- add localization for custom API server url
- allow storing custom API URL in config
- override endpoints if configured
- add textbox in online web settings

## Testing
- `dotnet build osu.sln -c Release` *(fails: NETSDK1147 workload requirements)*

------
https://chatgpt.com/codex/tasks/task_e_687a58b2ab7c833194bd6688d419d05b